### PR TITLE
Refactor serializer undefined assertions

### DIFF
--- a/src/presentation/response/serializers/AttributionSource/AttributionSourceSerializer.ts
+++ b/src/presentation/response/serializers/AttributionSource/AttributionSourceSerializer.ts
@@ -1,18 +1,14 @@
 import {CustomSerializer} from "@/src/presentation/response/serializers/CustomSerializer.js";
 import {AttributionSource} from "@/src/models/entities/AttributionSource.js";
-import {assertNoUndefinedProps} from "@/src/presentation/response/serializers/serializerUtils.js";
 
 class AttributionSourceSerializer extends CustomSerializer<AttributionSource> {
     serialize(attributionSource: AttributionSource, {assertNoUndefined = true} = {}) {
-        const pojo = {
+        return this.finalizePojo({
             id: attributionSource.id,
             name: attributionSource.name,
             url: attributionSource.url,
             logoUrl: attributionSource.logoUrl
-        }
-        if (assertNoUndefined)
-            assertNoUndefinedProps(pojo);
-        return pojo;
+        }, assertNoUndefined);
     }
 }
 

--- a/src/presentation/response/serializers/Collection/CollectionLoggedInSerializer.ts
+++ b/src/presentation/response/serializers/Collection/CollectionLoggedInSerializer.ts
@@ -2,7 +2,6 @@ import {CustomSerializer} from "@/src/presentation/response/serializers/CustomSe
 import {Collection} from "@/src/models/entities/Collection.js";
 import {textSummaryLoggedInSerializer} from "@/src/presentation/response/serializers/Text/TextSummaryLoggedInSerializer.js";
 import {ViewDescription} from "@/src/models/viewResolver.js";
-import {assertNoUndefinedProps} from "@/src/presentation/response/serializers/serializerUtils.js";
 
 export class CollectionLoggedInSerializer extends CustomSerializer<Collection> {
     static readonly view: ViewDescription = {
@@ -36,7 +35,7 @@ export class CollectionLoggedInSerializer extends CustomSerializer<Collection> {
     }
 
     serialize(collection: Collection, {assertNoUndefined = true} = {}): any {
-        const pojo = {
+        return this.finalizePojo({
             id: collection.id,
             title: collection.title,
             description: collection.description,
@@ -50,12 +49,9 @@ export class CollectionLoggedInSerializer extends CustomSerializer<Collection> {
 
             vocabsByLevel: collection.vocabsByLevel,
             isBookmarked: collection.isBookmarked,
-        };
-
-        if (assertNoUndefined)
-            assertNoUndefinedProps(pojo);
-        return pojo;
+        }, assertNoUndefined);
     }
 }
 
 export const collectionLoggedInSerializer = new CollectionLoggedInSerializer();
+

--- a/src/presentation/response/serializers/Collection/CollectionSerializer.ts
+++ b/src/presentation/response/serializers/Collection/CollectionSerializer.ts
@@ -2,7 +2,6 @@ import {CustomSerializer} from "@/src/presentation/response/serializers/CustomSe
 import {Collection} from "@/src/models/entities/Collection.js";
 import {textSummarySerializer} from "@/src/presentation/response/serializers/Text/TextSummarySerializer.js";
 import {ViewDescription} from "@/src/models/viewResolver.js";
-import {assertNoUndefinedProps} from "@/src/presentation/response/serializers/serializerUtils.js";
 
 class CollectionSerializer extends CustomSerializer<Collection> {
     static readonly view: ViewDescription = {
@@ -36,7 +35,7 @@ class CollectionSerializer extends CustomSerializer<Collection> {
     }
 
     serialize(collection: Collection, {assertNoUndefined = true} = {}): any {
-        const pojo = {
+        return this.finalizePojo({
             id: collection.id,
             title: collection.title,
             description: collection.description,
@@ -47,11 +46,7 @@ class CollectionSerializer extends CustomSerializer<Collection> {
             language: collection.language.code,
             addedBy: collection.addedBy.user.username,
             texts: textSummarySerializer.serializeList(collection.texts.getItems(), {assertNoUndefined}),
-        };
-
-        if (assertNoUndefined)
-            assertNoUndefinedProps(pojo);
-        return pojo;
+        }, assertNoUndefined);
     }
 }
 

--- a/src/presentation/response/serializers/Collection/CollectionSummaryLoggedInSerializer.ts
+++ b/src/presentation/response/serializers/Collection/CollectionSummaryLoggedInSerializer.ts
@@ -1,7 +1,6 @@
 import {CustomSerializer} from "@/src/presentation/response/serializers/CustomSerializer.js";
 import {Collection} from "@/src/models/entities/Collection.js";
 import {ViewDescription} from "@/src/models/viewResolver.js";
-import {assertNoUndefinedProps} from "@/src/presentation/response/serializers/serializerUtils.js";
 
 class CollectionSummaryLoggedInSerializer extends CustomSerializer<Collection> {
     static readonly view: ViewDescription = {
@@ -22,7 +21,7 @@ class CollectionSummaryLoggedInSerializer extends CustomSerializer<Collection> {
     }
 
     serialize(collection: Collection, {assertNoUndefined = true} = {}): any {
-        const pojo = {
+        return this.finalizePojo({
             id: collection.id,
             title: collection.title,
             description: collection.description,
@@ -35,11 +34,7 @@ class CollectionSummaryLoggedInSerializer extends CustomSerializer<Collection> {
 
             vocabsByLevel: collection.vocabsByLevel,
             isBookmarked: collection.isBookmarked,
-        };
-
-        if (assertNoUndefined)
-            assertNoUndefinedProps(pojo);
-        return pojo;
+        }, assertNoUndefined);
     }
 }
 

--- a/src/presentation/response/serializers/Collection/CollectionSummarySerializer.ts
+++ b/src/presentation/response/serializers/Collection/CollectionSummarySerializer.ts
@@ -1,7 +1,6 @@
 import {CustomSerializer} from "@/src/presentation/response/serializers/CustomSerializer.js";
 import {Collection} from "@/src/models/entities/Collection.js";
 import {ViewDescription} from "@/src/models/viewResolver.js";
-import {assertNoUndefinedProps} from "@/src/presentation/response/serializers/serializerUtils.js";
 
 
 class CollectionSummarySerializer extends CustomSerializer<Collection> {
@@ -23,7 +22,7 @@ class CollectionSummarySerializer extends CustomSerializer<Collection> {
     }
 
     serialize(collection: Collection, {assertNoUndefined = true} = {}): any {
-        const pojo = {
+        return this.finalizePojo({
             id: collection.id,
             title: collection.title,
             description: collection.description,
@@ -33,11 +32,7 @@ class CollectionSummarySerializer extends CustomSerializer<Collection> {
 
             language: collection.language.code,
             addedBy: collection.addedBy.user.username,
-        };
-
-        if (assertNoUndefined)
-            assertNoUndefinedProps(pojo);
-        return pojo;
+        }, assertNoUndefined);
     }
 }
 

--- a/src/presentation/response/serializers/CustomSerializer.ts
+++ b/src/presentation/response/serializers/CustomSerializer.ts
@@ -1,11 +1,19 @@
 import {CustomBaseEntity} from "@/src/models/entities/CustomBaseEntity.js";
 import {ViewDescription} from "@/src/models/viewResolver.js";
+import {assertNoUndefinedProps} from "@/src/presentation/response/serializers/serializerUtils.js";
 
 
 export abstract class CustomSerializer<R extends CustomBaseEntity> {
     static readonly view: ViewDescription;
 
     abstract serialize(rootEntity: R, options: { assertNoUndefined: boolean }): any;
+
+    protected finalizePojo<T extends Record<string, any>>(pojo: T, assertNoUndefined: boolean): T {
+        if (assertNoUndefined) {
+            assertNoUndefinedProps(pojo);
+        }
+        return pojo;
+    }
 
     serializeList(rootEntities: R[], {assertNoUndefined = false} = {}) {
         return rootEntities.map(e => this.serialize(e, {assertNoUndefined}));

--- a/src/presentation/response/serializers/Dictionary/DictionarySerializer.ts
+++ b/src/presentation/response/serializers/Dictionary/DictionarySerializer.ts
@@ -1,21 +1,16 @@
 import {CustomSerializer} from "@/src/presentation/response/serializers/CustomSerializer.js";
 import {Dictionary} from "@/src/models/entities/Dictionary.js";
-import {assertNoUndefinedProps} from "@/src/presentation/response/serializers/serializerUtils.js";
 
 class DictionarySerializer extends CustomSerializer<Dictionary> {
     serialize(dictionary: Dictionary, {assertNoUndefined = true} = {}): any {
-        const pojo = {
+        return this.finalizePojo({
             id: dictionary.id,
             name: dictionary.name,
             lookupLink: dictionary.lookupLink,
             dictionaryLink: dictionary.dictionaryLink,
             language: dictionary.language.code,
             isPronunciation: dictionary.isPronunciation,
-        };
-
-        if (assertNoUndefined)
-            assertNoUndefinedProps(pojo);
-        return pojo;
+        }, assertNoUndefined);
     }
 }
 

--- a/src/presentation/response/serializers/HumanPronunciation/HumanPronunciationSerializer.ts
+++ b/src/presentation/response/serializers/HumanPronunciation/HumanPronunciationSerializer.ts
@@ -1,11 +1,10 @@
 import {CustomSerializer} from "@/src/presentation/response/serializers/CustomSerializer.js";
 import {HumanPronunciation} from "@/src/models/entities/HumanPronunciation.js";
 import {attributionSourceSerializer} from "@/src/presentation/response/serializers/AttributionSource/AttributionSourceSerializer.js";
-import {assertNoUndefinedProps} from "@/src/presentation/response/serializers/serializerUtils.js";
 
 class HumanPronunciationSerializer extends CustomSerializer<HumanPronunciation> {
     serialize(humanPronunciation: HumanPronunciation, {assertNoUndefined = true} = {}): any {
-        const pojo = {
+        return this.finalizePojo({
             id: humanPronunciation.id,
             url: humanPronunciation.url,
             text: humanPronunciation.text,
@@ -15,10 +14,7 @@ class HumanPronunciationSerializer extends CustomSerializer<HumanPronunciation> 
             speakerRegion: humanPronunciation.speakerRegion,
             attributionSource: humanPronunciation.attributionSource ? attributionSourceSerializer.serialize(humanPronunciation.attributionSource, {assertNoUndefined}) : null,
             attribution: humanPronunciation.attribution,
-        };
-        if (assertNoUndefined)
-            assertNoUndefinedProps(pojo);
-        return pojo;
+        }, assertNoUndefined);
     }
 }
 

--- a/src/presentation/response/serializers/Language/LanguageSerializer.ts
+++ b/src/presentation/response/serializers/Language/LanguageSerializer.ts
@@ -1,10 +1,9 @@
 import {CustomSerializer} from "@/src/presentation/response/serializers/CustomSerializer.js";
 import {Language} from "@/src/models/entities/Language.js";
-import {assertNoUndefinedProps} from "@/src/presentation/response/serializers/serializerUtils.js";
 
 class LanguageSerializer extends CustomSerializer<Language> {
     serialize(language: Language, {assertNoUndefined = true} = {}): any {
-        const pojo = {
+        return this.finalizePojo({
             id: language.id,
             code: language.code,
             name: language.name,
@@ -16,10 +15,7 @@ class LanguageSerializer extends CustomSerializer<Language> {
             color: language.color,
             levelThresholds: language.levelThresholds,
             learnersCount: Number(language.learnersCount),
-        };
-        if (assertNoUndefined)
-            assertNoUndefinedProps(pojo);
-        return pojo;
+        }, assertNoUndefined);
     }
 }
 

--- a/src/presentation/response/serializers/Language/LearnerLanguageSerializer.ts
+++ b/src/presentation/response/serializers/Language/LearnerLanguageSerializer.ts
@@ -2,11 +2,10 @@ import {CustomSerializer} from "@/src/presentation/response/serializers/CustomSe
 import {MapLearnerLanguage} from "@/src/models/entities/MapLearnerLanguage.js";
 import {translationLanguageSerializer} from "@/src/presentation/response/serializers/TranslationLanguage/TranslationLanguageSerializer.js";
 import {ttsVoiceSerializer} from "@/src/presentation/response/serializers/TTSVoice/TtsVoiceSerializer.js";
-import {assertNoUndefinedProps} from "@/src/presentation/response/serializers/serializerUtils.js";
 
 class LearnerLanguageSerializer extends CustomSerializer<MapLearnerLanguage> {
     serialize(mapping: MapLearnerLanguage, {assertNoUndefined = true} = {}): any {
-        const pojo = {
+        return this.finalizePojo({
             id: mapping.language.id,
             code: mapping.language.code,
             name: mapping.language.name,
@@ -22,10 +21,7 @@ class LearnerLanguageSerializer extends CustomSerializer<MapLearnerLanguage> {
             preferredTtsVoice: mapping.preferredTtsVoice ? ttsVoiceSerializer.serialize(mapping.preferredTtsVoice, {assertNoUndefined}) : null,
             preferredTranslationLanguages: translationLanguageSerializer.serializeList(mapping.preferredTranslationLanguages.getItems().map(m => m.translationLanguage), {assertNoUndefined}),
             isRtl: mapping.language.isRtl,
-        };
-        if (assertNoUndefined)
-            assertNoUndefinedProps(pojo);
-        return pojo;
+        }, assertNoUndefined);
     }
 }
 

--- a/src/presentation/response/serializers/Meaning/MeaningSerializer.ts
+++ b/src/presentation/response/serializers/Meaning/MeaningSerializer.ts
@@ -3,11 +3,10 @@ import {Meaning} from "@/src/models/entities/Meaning.js";
 import {attributionSourceSerializer} from "@/src/presentation/response/serializers/AttributionSource/AttributionSourceSerializer.js";
 import {vocabForMeaningSerializer} from "@/src/presentation/response/serializers/Vocab/VocabForMeaningSerializer.js";
 import {vocabVariantSerializer} from "@/src/presentation/response/serializers/VocabVariant/VocabVariantSerializer.js";
-import {assertNoUndefinedProps} from "@/src/presentation/response/serializers/serializerUtils.js";
 
 class MeaningSerializer extends CustomSerializer<Meaning> {
     serialize(meaning: Meaning, {assertNoUndefined = true} = {}): any {
-        const pojo = {
+        return this.finalizePojo({
             id: meaning.id,
             text: meaning.text,
             vocab: vocabForMeaningSerializer.serialize(meaning.vocab, {assertNoUndefined}),
@@ -18,10 +17,7 @@ class MeaningSerializer extends CustomSerializer<Meaning> {
             attributionSource: meaning.attributionSource ? attributionSourceSerializer.serialize(meaning.attributionSource, {assertNoUndefined}) : null,
             attribution: meaning.attribution,
             vocabVariant: meaning.vocabVariant ? vocabVariantSerializer.serialize(meaning.vocabVariant, {assertNoUndefined}) : null
-        };
-        if (assertNoUndefined)
-            assertNoUndefinedProps(pojo);
-        return pojo;
+        }, assertNoUndefined);
     }
 }
 

--- a/src/presentation/response/serializers/Meaning/MeaningSummerySerializer.ts
+++ b/src/presentation/response/serializers/Meaning/MeaningSummerySerializer.ts
@@ -1,11 +1,10 @@
 import {CustomSerializer} from "@/src/presentation/response/serializers/CustomSerializer.js";
 import {Meaning} from "@/src/models/entities/Meaning.js";
 import {vocabVariantSerializer} from "@/src/presentation/response/serializers/VocabVariant/VocabVariantSerializer.js";
-import {assertNoUndefinedProps} from "@/src/presentation/response/serializers/serializerUtils.js";
 
 class MeaningSummerySerializer extends CustomSerializer<Meaning> {
     serialize(meaning: Meaning, {assertNoUndefined = true} = {}): any {
-        const pojo = {
+        return this.finalizePojo({
             id: meaning.id,
             text: meaning.text,
             vocab: meaning.vocab.id,
@@ -16,10 +15,7 @@ class MeaningSummerySerializer extends CustomSerializer<Meaning> {
             attributionSource: meaning.attributionSource ? meaning.attributionSource.id : null,
             attribution: meaning.attribution,
             vocabVariant: meaning.vocabVariant ? vocabVariantSerializer.serialize(meaning.vocabVariant) : null
-        };
-        if (assertNoUndefined)
-            assertNoUndefinedProps(pojo);
-        return pojo;
+        }, assertNoUndefined);
     }
 }
 

--- a/src/presentation/response/serializers/Notification/NotificationSerializer.ts
+++ b/src/presentation/response/serializers/Notification/NotificationSerializer.ts
@@ -1,17 +1,13 @@
 import {CustomSerializer} from "@/src/presentation/response/serializers/CustomSerializer.js";
 import {Notification} from "@/src/models/entities/Notification.js";
-import {assertNoUndefinedProps} from "@/src/presentation/response/serializers/serializerUtils.js";
 
 class NotificationSerializer extends CustomSerializer<Notification> {
     serialize(notification: Notification, {assertNoUndefined = true} = {}): any {
-        const pojo = {
+        return this.finalizePojo({
             id: notification.id,
             text: notification.text,
             createdDate: notification.createdDate.toISOString(),
-        };
-        if (assertNoUndefined)
-            assertNoUndefinedProps(pojo);
-        return pojo;
+        }, assertNoUndefined);
     }
 }
 

--- a/src/presentation/response/serializers/Profile/ProfileSerializer.ts
+++ b/src/presentation/response/serializers/Profile/ProfileSerializer.ts
@@ -1,20 +1,16 @@
 import {CustomSerializer} from "@/src/presentation/response/serializers/CustomSerializer.js";
 import {Profile} from "@/src/models/entities/Profile.js";
 import {languageSerializer} from "@/src/presentation/response/serializers/Language/LanguageSerializer.js";
-import {assertNoUndefinedProps} from "@/src/presentation/response/serializers/serializerUtils.js";
 
 class ProfileSerializer extends CustomSerializer<Profile> {
     serialize(profile: Profile, {assertNoUndefined = true} = {}): any {
-        const pojo = {
+        return this.finalizePojo({
             id: profile.id,
             languagesLearning: languageSerializer.serializeList(profile.languagesLearning.getItems(), {assertNoUndefined}),
             profilePicture: profile.profilePicture,
             bio: profile.bio,
             isPublic: profile.isPublic
-        };
-        if (assertNoUndefined)
-            assertNoUndefinedProps(pojo);
-        return pojo;
+        }, assertNoUndefined);
     }
 }
 

--- a/src/presentation/response/serializers/TTSPronunciation/TtsPronunciationSerializer.ts
+++ b/src/presentation/response/serializers/TTSPronunciation/TtsPronunciationSerializer.ts
@@ -1,21 +1,17 @@
 import {CustomSerializer} from "@/src/presentation/response/serializers/CustomSerializer.js";
 import {TTSPronunciation} from "@/src/models/entities/TTSPronunciation.js";
 import {ttsVoiceSerializer} from "@/src/presentation/response/serializers/TTSVoice/TtsVoiceSerializer.js";
-import {assertNoUndefinedProps} from "@/src/presentation/response/serializers/serializerUtils.js";
 
 class TTSPronunciationSerializer extends CustomSerializer<TTSPronunciation> {
     serialize(ttsPronunciation: TTSPronunciation, {assertNoUndefined = true} = {}): any {
-        const pojo = {
+        return this.finalizePojo({
             id: ttsPronunciation.id,
             url: ttsPronunciation.url,
             addedOn: ttsPronunciation.addedOn.toISOString(),
             voice: ttsVoiceSerializer.serialize(ttsPronunciation.voice),
             vocabId: ttsPronunciation.vocab?.id ?? null,
             variantId: ttsPronunciation.vocabVariant?.id ?? null,
-        };
-        if (assertNoUndefined)
-            assertNoUndefinedProps(pojo);
-        return pojo;
+        }, assertNoUndefined);
     }
 }
 

--- a/src/presentation/response/serializers/TTSVoice/TtsVoiceSerializer.ts
+++ b/src/presentation/response/serializers/TTSVoice/TtsVoiceSerializer.ts
@@ -1,10 +1,9 @@
 import {CustomSerializer} from "@/src/presentation/response/serializers/CustomSerializer.js";
 import {TTSVoice} from "@/src/models/entities/TTSVoice.js";
-import {assertNoUndefinedProps} from "@/src/presentation/response/serializers/serializerUtils.js";
 
 class TTSVoiceSerializer extends CustomSerializer<TTSVoice> {
     serialize(ttsVoice: TTSVoice, {assertNoUndefined = true} = {}): any {
-        const pojo = {
+        return this.finalizePojo({
             id: ttsVoice.id,
             code: ttsVoice.code,
             name: ttsVoice.name,
@@ -13,10 +12,7 @@ class TTSVoiceSerializer extends CustomSerializer<TTSVoice> {
             accentCountryCode: ttsVoice.accentCountryCode,
             language: ttsVoice.language.code,
             isDefault: ttsVoice.isDefault,
-        };
-        if (assertNoUndefined)
-            assertNoUndefinedProps(pojo);
-        return pojo;
+        }, assertNoUndefined);
     }
 }
 

--- a/src/presentation/response/serializers/Text/TextLoggedInSerializer.ts
+++ b/src/presentation/response/serializers/Text/TextLoggedInSerializer.ts
@@ -1,12 +1,11 @@
 import {CustomSerializer} from "@/src/presentation/response/serializers/CustomSerializer.js";
 import {Text} from "@/src/models/entities/Text.js";
 import {collectionSummarySerializer} from "@/src/presentation/response/serializers/Collection/CollectionSummarySerializer.js";
-import {assertNoUndefinedProps} from "@/src/presentation/response/serializers/serializerUtils.js";
 
 
 class TextLoggedInSerializer extends CustomSerializer<Text> {
     serialize(text: Text, {assertNoUndefined = true} = {}): any {
-        const pojo = {
+        return this.finalizePojo({
             id: text.id,
             title: text.title,
             content: text.content,
@@ -27,10 +26,7 @@ class TextLoggedInSerializer extends CustomSerializer<Text> {
 
             vocabsByLevel: text.vocabsByLevel,
             isBookmarked: text.isBookmarked
-        };
-        if (assertNoUndefined)
-            assertNoUndefinedProps(pojo);
-        return pojo;
+        }, assertNoUndefined);
     }
 }
 

--- a/src/presentation/response/serializers/Text/TextSerializer.ts
+++ b/src/presentation/response/serializers/Text/TextSerializer.ts
@@ -1,12 +1,11 @@
 import {CustomSerializer} from "@/src/presentation/response/serializers/CustomSerializer.js";
 import {Text} from "@/src/models/entities/Text.js";
 import {collectionSummarySerializer} from "@/src/presentation/response/serializers/Collection/CollectionSummarySerializer.js";
-import {assertNoUndefinedProps} from "@/src/presentation/response/serializers/serializerUtils.js";
 
 
 class TextSerializer extends CustomSerializer<Text> {
     serialize(text: Text, {assertNoUndefined = true} = {}): any {
-        const pojo = {
+        return this.finalizePojo({
             id: text.id,
             title: text.title,
             content: text.content,
@@ -24,10 +23,7 @@ class TextSerializer extends CustomSerializer<Text> {
             level: text.level,
             language: text.language.code,
             pastViewersCount: Number(text.pastViewersCount),
-        };
-        if (assertNoUndefined)
-            assertNoUndefinedProps(pojo);
-        return pojo;
+        }, assertNoUndefined);
     }
 }
 

--- a/src/presentation/response/serializers/Text/TextSummaryLoggedInSerializer.ts
+++ b/src/presentation/response/serializers/Text/TextSummaryLoggedInSerializer.ts
@@ -1,11 +1,10 @@
 import {CustomSerializer} from "@/src/presentation/response/serializers/CustomSerializer.js";
 import {Text} from "@/src/models/entities/Text.js";
-import {assertNoUndefinedProps} from "@/src/presentation/response/serializers/serializerUtils.js";
 
 
 class TextSummaryLoggedInSerializer extends CustomSerializer<Text> {
     serialize(text: Text, {assertNoUndefined = true} = {}): any {
-        const pojo = {
+        return this.finalizePojo({
             id: text.id,
             title: text.title,
             audio: text.audio,
@@ -24,10 +23,7 @@ class TextSummaryLoggedInSerializer extends CustomSerializer<Text> {
 
             vocabsByLevel: text.vocabsByLevel,
             isBookmarked: text.isBookmarked
-        };
-        if (assertNoUndefined)
-            assertNoUndefinedProps(pojo);
-        return pojo;
+        }, assertNoUndefined);
     }
 }
 

--- a/src/presentation/response/serializers/Text/TextSummarySerializer.ts
+++ b/src/presentation/response/serializers/Text/TextSummarySerializer.ts
@@ -1,11 +1,10 @@
 import {CustomSerializer} from "@/src/presentation/response/serializers/CustomSerializer.js";
 import {Text} from "@/src/models/entities/Text.js";
-import {assertNoUndefinedProps} from "@/src/presentation/response/serializers/serializerUtils.js";
 
 
 class TextSummarySerializer extends CustomSerializer<Text> {
     serialize(text: Text, {assertNoUndefined = true} = {}): any {
-        const pojo = {
+        return this.finalizePojo({
             id: text.id,
             title: text.title,
             audio: text.audio,
@@ -21,10 +20,7 @@ class TextSummarySerializer extends CustomSerializer<Text> {
 
             addedBy: text.addedBy.user.username,
             language: text.language.code,
-        };
-        if (assertNoUndefined)
-            assertNoUndefinedProps(pojo);
-        return pojo;
+        }, assertNoUndefined);
     }
 }
 

--- a/src/presentation/response/serializers/TextHistoryEntry/TextHistoryEntrySerializer.ts
+++ b/src/presentation/response/serializers/TextHistoryEntry/TextHistoryEntrySerializer.ts
@@ -2,12 +2,11 @@ import {CustomSerializer} from "@/src/presentation/response/serializers/CustomSe
 import {TextHistoryEntry} from "@/src/models/entities/TextHistoryEntry.js";
 import {AnonymousUser} from "@/src/models/entities/auth/User.js";
 import {collectionSummarySerializer} from "@/src/presentation/response/serializers/Collection/CollectionSummarySerializer.js";
-import {assertNoUndefinedProps} from "@/src/presentation/response/serializers/serializerUtils.js";
 
 
 class TextHistoryEntrySerializer extends CustomSerializer<TextHistoryEntry> {
     serialize(textHistoryEntry: TextHistoryEntry, {assertNoUndefined = true} = {}): any {
-        const pojo = {
+        return this.finalizePojo({
             id: textHistoryEntry.text.id,
             title: textHistoryEntry.text.title,
             content: textHistoryEntry.text.content,
@@ -30,10 +29,7 @@ class TextHistoryEntrySerializer extends CustomSerializer<TextHistoryEntry> {
 
             timeViewed: textHistoryEntry.timeViewed.toISOString(),
             pastViewer: textHistoryEntry.pastViewer?.user.username ?? AnonymousUser.name,
-        };
-        if (assertNoUndefined)
-            assertNoUndefinedProps(pojo);
-        return pojo;
+        }, assertNoUndefined);
     }
 }
 

--- a/src/presentation/response/serializers/TranslationLanguage/TranslationLanguageSerializer.ts
+++ b/src/presentation/response/serializers/TranslationLanguage/TranslationLanguageSerializer.ts
@@ -1,18 +1,14 @@
 import {CustomSerializer} from "@/src/presentation/response/serializers/CustomSerializer.js";
 import {TranslationLanguage} from "@/src/models/entities/TranslationLanguage.js";
-import {assertNoUndefinedProps} from "@/src/presentation/response/serializers/serializerUtils.js";
 
 class TranslationLanguageSerializer extends CustomSerializer<TranslationLanguage> {
     serialize(translationLanguage: TranslationLanguage, {assertNoUndefined = true} = {}): any {
-        const pojo = {
+        return this.finalizePojo({
             id: translationLanguage.id,
             code: translationLanguage.code,
             name: translationLanguage.name,
             isDefault: translationLanguage.isDefault
-        };
-        if (assertNoUndefined)
-            assertNoUndefinedProps(pojo);
-        return pojo;
+        }, assertNoUndefined);
     }
 }
 

--- a/src/presentation/response/serializers/User/UserPrivateSerializer.ts
+++ b/src/presentation/response/serializers/User/UserPrivateSerializer.ts
@@ -1,21 +1,17 @@
 import {CustomSerializer} from "@/src/presentation/response/serializers/CustomSerializer.js";
 import {User} from "@/src/models/entities/auth/User.js";
 import {profileSerializer} from "@/src/presentation/response/serializers/Profile/ProfileSerializer.js";
-import {assertNoUndefinedProps} from "@/src/presentation/response/serializers/serializerUtils.js";
 
 class UserPrivateSerializer extends CustomSerializer<User> {
     serialize(user: User, {assertNoUndefined = true} = {}): any {
-        const pojo = {
+        return this.finalizePojo({
             username: user.username,
             email: `${user.email.charAt(0)}${"*".repeat(10)}@${"*".repeat(8)}`,
             profile: profileSerializer.serialize(user.profile, {assertNoUndefined}),
             isEmailConfirmed: user.isEmailConfirmed,
             isBanned: user.isBanned,
             isPendingEmailChange: user.isPendingEmailChange
-        };
-        if (assertNoUndefined)
-            assertNoUndefinedProps(pojo);
-        return pojo;
+        }, assertNoUndefined);
     }
 }
 

--- a/src/presentation/response/serializers/User/UserPublicSerializer.ts
+++ b/src/presentation/response/serializers/User/UserPublicSerializer.ts
@@ -1,18 +1,14 @@
 import {CustomSerializer} from "@/src/presentation/response/serializers/CustomSerializer.js";
 import {User} from "@/src/models/entities/auth/User.js";
 import {profileSerializer} from "@/src/presentation/response/serializers/Profile/ProfileSerializer.js";
-import {assertNoUndefinedProps} from "@/src/presentation/response/serializers/serializerUtils.js";
 
 class UserPublicSerializer extends CustomSerializer<User> {
     serialize(user: User, {assertNoUndefined = true} = {}): any {
-        const pojo = {
+        return this.finalizePojo({
             username: user.username,
             profile: profileSerializer.serialize(user.profile, {assertNoUndefined}),
             isBanned: user.isBanned,
-        };
-        if (assertNoUndefined)
-            assertNoUndefinedProps(pojo);
-        return pojo;
+        }, assertNoUndefined);
     }
 }
 

--- a/src/presentation/response/serializers/User/UserSignUpSerializer.ts
+++ b/src/presentation/response/serializers/User/UserSignUpSerializer.ts
@@ -1,19 +1,15 @@
 import {CustomSerializer} from "@/src/presentation/response/serializers/CustomSerializer.js";
 import {User} from "@/src/models/entities/auth/User.js";
-import {assertNoUndefinedProps} from "@/src/presentation/response/serializers/serializerUtils.js";
 
 class UserSignUpSerializer extends CustomSerializer<User> {
     serialize(user: User, {assertNoUndefined = true} = {}): any {
-        const pojo = {
+        return this.finalizePojo({
             username: user.username,
             email: `${user.email.charAt(0)}${"*".repeat(10)}@${"*".repeat(8)}`,
             isEmailConfirmed: user.isEmailConfirmed,
             isBanned: user.isBanned,
             isPendingEmailChange: user.isPendingEmailChange
-        };
-        if (assertNoUndefined)
-            assertNoUndefinedProps(pojo);
-        return pojo;
+        }, assertNoUndefined);
     }
 }
 

--- a/src/presentation/response/serializers/Vocab/LearnerVocabForTextSerializer.ts
+++ b/src/presentation/response/serializers/Vocab/LearnerVocabForTextSerializer.ts
@@ -4,7 +4,6 @@ import {Vocab} from "@/src/models/entities/Vocab.js";
 import {VocabLevel} from "dzelda-common";
 import {vocabTagSerializer} from "@/src/presentation/response/serializers/VocabTag/VocabTagSerializer.js";
 import {vocabVariantSerializer} from "@/src/presentation/response/serializers/VocabVariant/VocabVariantSerializer.js";
-import {assertNoUndefinedProps} from "@/src/presentation/response/serializers/serializerUtils.js";
 
 
 class LearnerVocabForTextSerializer extends CustomSerializer<Vocab | MapLearnerVocab> {
@@ -13,7 +12,7 @@ class LearnerVocabForTextSerializer extends CustomSerializer<Vocab | MapLearnerV
         const isMapping = vocabOrMapping instanceof MapLearnerVocab;
         const internalVocab = isMapping ? vocabOrMapping.vocab : vocabOrMapping;
 
-        const pojo = {
+        return this.finalizePojo({
             id: internalVocab.id,
             text: internalVocab.text,
             isPhrase: internalVocab.isPhrase,
@@ -27,10 +26,7 @@ class LearnerVocabForTextSerializer extends CustomSerializer<Vocab | MapLearnerV
             // mapping fields
             level: isMapping ? vocabOrMapping.level : VocabLevel.NEW,
             notes: isMapping ? vocabOrMapping.notes : null,
-        };
-        if (assertNoUndefined)
-            assertNoUndefinedProps(pojo);
-        return pojo;
+        }, assertNoUndefined);
     }
 }
 

--- a/src/presentation/response/serializers/Vocab/LearnerVocabSerializer.ts
+++ b/src/presentation/response/serializers/Vocab/LearnerVocabSerializer.ts
@@ -3,11 +3,10 @@ import {MapLearnerVocab} from "@/src/models/entities/MapLearnerVocab.js";
 import {meaningSummerySerializer} from "@/src/presentation/response/serializers/Meaning/MeaningSummerySerializer.js";
 import {vocabVariantSerializer} from "@/src/presentation/response/serializers/VocabVariant/VocabVariantSerializer.js";
 import {vocabTagSerializer} from "@/src/presentation/response/serializers/VocabTag/VocabTagSerializer.js";
-import {assertNoUndefinedProps} from "@/src/presentation/response/serializers/serializerUtils.js";
 
 class LearnerVocabSerializer extends CustomSerializer<MapLearnerVocab> {
     serialize(mapping: MapLearnerVocab, {assertNoUndefined = true} = {}): any {
-        const pojo = {
+        return this.finalizePojo({
             id: mapping.vocab.id,
             text: mapping.vocab.text,
             isPhrase: mapping.vocab.isPhrase,
@@ -21,10 +20,7 @@ class LearnerVocabSerializer extends CustomSerializer<MapLearnerVocab> {
             tags: vocabTagSerializer.serializeList(mapping.vocab.tags.getItems(), {assertNoUndefined}),
             rootForms: mapping.vocab.rootForms.getItems().map(v => v.text),
             variants: vocabVariantSerializer.serializeList(mapping.vocab.vocabVariants.getItems(), {assertNoUndefined})
-        };
-        if (assertNoUndefined)
-            assertNoUndefinedProps(pojo);
-        return pojo;
+        }, assertNoUndefined);
     }
 }
 

--- a/src/presentation/response/serializers/Vocab/VocabForMeaningSerializer.ts
+++ b/src/presentation/response/serializers/Vocab/VocabForMeaningSerializer.ts
@@ -1,20 +1,16 @@
 import {CustomSerializer} from "@/src/presentation/response/serializers/CustomSerializer.js";
 import {Vocab} from "@/src/models/entities/Vocab.js";
-import {assertNoUndefinedProps} from "@/src/presentation/response/serializers/serializerUtils.js";
 
 class VocabForMeaningSerializer extends CustomSerializer<Vocab> {
     serialize(vocab: Vocab, {assertNoUndefined = true} = {}): any {
-        const pojo = {
+        return this.finalizePojo({
             id: vocab.id,
             text: vocab.text,
             isPhrase: vocab.isPhrase,
             language: vocab.language.code,
             learnersCount: Number(vocab.learnersCount!),
             textsCount: Number(vocab.textsCount!),
-        };
-        if (assertNoUndefined)
-            assertNoUndefinedProps(pojo);
-        return pojo;
+        }, assertNoUndefined);
     }
 }
 

--- a/src/presentation/response/serializers/Vocab/VocabSerializer.ts
+++ b/src/presentation/response/serializers/Vocab/VocabSerializer.ts
@@ -3,11 +3,10 @@ import {Vocab} from "@/src/models/entities/Vocab.js";
 import {meaningSummerySerializer} from "@/src/presentation/response/serializers/Meaning/MeaningSummerySerializer.js";
 import {vocabTagSerializer} from "@/src/presentation/response/serializers/VocabTag/VocabTagSerializer.js";
 import {vocabVariantSerializer} from "@/src/presentation/response/serializers/VocabVariant/VocabVariantSerializer.js";
-import {assertNoUndefinedProps} from "@/src/presentation/response/serializers/serializerUtils.js";
 
 class VocabSerializer extends CustomSerializer<Vocab> {
     serialize(vocab: Vocab, {assertNoUndefined = true} = {}): any {
-        const pojo = {
+        return this.finalizePojo({
             id: vocab.id,
             text: vocab.text,
             isPhrase: vocab.isPhrase,
@@ -17,10 +16,7 @@ class VocabSerializer extends CustomSerializer<Vocab> {
             variants: vocabVariantSerializer.serializeList(vocab.vocabVariants.getItems(), {assertNoUndefined}),
             learnersCount: Number(vocab.learnersCount!),
             textsCount: Number(vocab.textsCount!),
-        };
-        if (assertNoUndefined)
-            assertNoUndefinedProps(pojo);
-        return pojo;
+        }, assertNoUndefined);
     }
 }
 

--- a/src/presentation/response/serializers/VocabTag/VocabTagSerializer.ts
+++ b/src/presentation/response/serializers/VocabTag/VocabTagSerializer.ts
@@ -1,17 +1,13 @@
 import {CustomSerializer} from "@/src/presentation/response/serializers/CustomSerializer.js";
 import {VocabTag} from "@/src/models/entities/VocabTag.js";
-import {assertNoUndefinedProps} from "@/src/presentation/response/serializers/serializerUtils.js";
 
 class VocabTagSerializer extends CustomSerializer<VocabTag> {
     serialize(vocabTag: VocabTag, {assertNoUndefined = true} = {}): any {
-        const pojo = {
+        return this.finalizePojo({
             id: vocabTag.id,
             name: vocabTag.name,
             category: vocabTag.category?.name ?? null,
-        };
-        if (assertNoUndefined)
-            assertNoUndefinedProps(pojo);
-        return pojo;
+        }, assertNoUndefined);
     }
 }
 

--- a/src/presentation/response/serializers/VocabVariant/VocabVariantSerializer.ts
+++ b/src/presentation/response/serializers/VocabVariant/VocabVariantSerializer.ts
@@ -1,17 +1,13 @@
 import {CustomSerializer} from "@/src/presentation/response/serializers/CustomSerializer.js";
 import {VocabVariant} from "@/src/models/entities/VocabVariant.js";
-import {assertNoUndefinedProps} from "@/src/presentation/response/serializers/serializerUtils.js";
 
 class VocabVariantSerializer extends CustomSerializer<VocabVariant> {
     serialize(vocabVariant: VocabVariant, {assertNoUndefined = true} = {}): any {
-        const pojo = {
+        return this.finalizePojo({
             id: vocabVariant.id,
             text: vocabVariant.text,
             ttsPronunciationUrl: vocabVariant.ttsPronunciations.getItems().pop()?.url ?? null,
-        };
-        if (assertNoUndefined)
-            assertNoUndefinedProps(pojo);
-        return pojo;
+        }, assertNoUndefined);
     }
 }
 


### PR DESCRIPTION
## Summary
- centralize undefined property assertions in `CustomSerializer`
- reuse new helper across all serializers

## Testing
- `npm test` *(fails: 403 Forbidden when fetching from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_685e7492965c832bb4537ab9925494b4